### PR TITLE
Upgrade/dynamic loading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'magpiebrigde.intellij'
-version '1.1'
+version '1.2'
 
 repositories {
     mavenCentral()
@@ -17,12 +17,12 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2019.2'
+    version '2020.2'
     plugins= ['java']
 }
 patchPluginXml {
     changeNotes """
-      Requires 2019.2+<br/>
+      Requires 2020.2+<br/>
       Supports 2020.2 EAP
     """
     untilBuild null

--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,12 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2020.2'
+    version '2020.1'
     plugins= ['java']
 }
 patchPluginXml {
     changeNotes """
-      Requires 2020.2+<br/>
+      Requires 2020.1+<br/>
       Supports 2020.2 EAP
     """
     untilBuild null

--- a/src/main/java/magpiebridge/intellij/plugin/ProjectLSPService.java
+++ b/src/main/java/magpiebridge/intellij/plugin/ProjectLSPService.java
@@ -1,6 +1,7 @@
 package magpiebridge.intellij.plugin;
 
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.components.Service;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.openapi.util.Disposer;
@@ -11,7 +12,8 @@ import java.io.IOException;
 /**
  * Define a project-level LSP service.
  */
-public class ProjectLSPService implements StartupActivity, Disposable {
+@Service
+public final class ProjectLSPService implements StartupActivity, Disposable {
     private Project project;
 
     @Override

--- a/src/main/java/magpiebridge/intellij/plugin/ProjectStart.java
+++ b/src/main/java/magpiebridge/intellij/plugin/ProjectStart.java
@@ -1,0 +1,16 @@
+package magpiebridge.intellij.plugin;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.util.Disposer;
+import org.jetbrains.annotations.NotNull;
+
+public class ProjectStart implements StartupActivity {
+  @Override
+  public void runActivity(@NotNull Project project) {
+    ProjectLSPService plsp = project.getService(ProjectLSPService.class);
+    plsp.runActivity(project);
+  }
+}

--- a/src/main/java/magpiebridge/intellij/plugin/QuickFixes.java
+++ b/src/main/java/magpiebridge/intellij/plugin/QuickFixes.java
@@ -2,6 +2,7 @@ package magpiebridge.intellij.plugin;
 
 import com.intellij.codeInsight.intention.AbstractIntentionAction;
 import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.components.Service;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
@@ -21,12 +22,12 @@ import java.awt.*;
 import java.util.List;
 import java.util.*;
 
-public class QuickFixes extends AbstractIntentionAction {
+@Service
+public final class QuickFixes extends AbstractIntentionAction {
 
     public static class QuickFix {
-        private Either<Command, CodeAction> action;
-
-        private LanguageServer server;
+        private final Either<Command, CodeAction> action;
+        private final LanguageServer server;
 
         public QuickFix(Command action, LanguageServer server) {
             this(Either.forLeft(action), server);
@@ -91,9 +92,7 @@ public class QuickFixes extends AbstractIntentionAction {
        int endOffset = doc.getLineStartOffset(end.getLine()) + end.getCharacter();
 
        List<QuickFix> fixes = new ArrayList<>();
-       lenses.forEach(c ->  {
-           fixes.add(new QuickFix(c, server));
-       });
+       lenses.forEach(c -> fixes.add(new QuickFix(c, server)));
 
         IPopupChooserBuilder<QuickFix> popup = JBPopupFactory.getInstance().createPopupChooserBuilder(fixes);
 
@@ -127,9 +126,7 @@ public class QuickFixes extends AbstractIntentionAction {
         int endOffset = doc.getLineStartOffset(end.getLine()) + end.getCharacter();
 
         List<QuickFix> fixes = new ArrayList<>();
-        actions.forEach(c ->  {
-            fixes.add(new QuickFix(c, server));
-        });
+        actions.forEach(c -> fixes.add(new QuickFix(c, server)));
         IPopupChooserBuilder<QuickFix> popup = JBPopupFactory.getInstance().createPopupChooserBuilder(fixes);
 
         if (! lowerBound.containsKey(doc)) { lowerBound.put(doc, new TreeMap<>()); }

--- a/src/main/java/magpiebridge/intellij/plugin/ServerLauncher.java
+++ b/src/main/java/magpiebridge/intellij/plugin/ServerLauncher.java
@@ -149,9 +149,9 @@ public class ServerLauncher {
         }).start();
     }
 
-    public static void closeProject(Project p) {
-        projects.remove(p);
-        shutDown(p, () -> services.remove(p));
+    public static void closeProject(Project project) {
+        projects.remove(project);
+        shutDown(project, () -> services.remove(project));
     }
 
     public static void shutDown(Project p, Runnable onFinish) {

--- a/src/main/java/magpiebridge/intellij/plugin/Service.java
+++ b/src/main/java/magpiebridge/intellij/plugin/Service.java
@@ -141,7 +141,7 @@ public class Service {
     public Service(Project project, LanguageServer server, LanguageClient lc) {
         this.project = project;
         this.server = server;
-        this.codeActions = project.getComponent(QuickFixes.class);
+        this.codeActions = project.getService(QuickFixes.class);
 
         if (server instanceof LanguageClientAware) {
             ((LanguageClientAware)server).connect(lc);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,21 +26,13 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <projectConfigurable instance="magpiebridge.intellij.plugin.Configuration"/>
-        <postStartupActivity implementation="magpiebridge.intellij.plugin.ProjectLSPService"/>
+        <postStartupActivity implementation="magpiebridge.intellij.plugin.ProjectStart"/>
         <intentionAction>
             <className>magpiebridge.intellij.plugin.QuickFixes</className>
             <category>SDK intentions</category>
         </intentionAction>
     </extensions>
 
-    <project-components>
-        <component>
-            <implementation-class>magpiebridge.intellij.plugin.QuickFixes</implementation-class>
-        </component>
-        <!--<component>
-            <implementation-class>magpiebridge.intellij.plugin.ProjectLSPService</implementation-class>
-        </component>-->
-    </project-components>
 
     <actions>
         <!-- Add your actions here -->


### PR DESCRIPTION
closes #5

:+1: faster dev cycle - no IDE restart required;
:-1:  minimal requirement goes up to IntelliJ IDEA Version 2020.1

